### PR TITLE
add optimized method for Jaccard distance and len(a|b)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,40 +51,45 @@ Output of ``$ make bench``::
 
     sparse set
     100 runs with sets of 200 random elements n s.t. 0 <= n < 40000
-                set()  RoaringBitmap()    ratio
-    init      0.00124          0.00788    0.158
-    and       0.00125         0.000196     6.39
-    or        0.00202         0.000243     8.31
-    xor       0.00172         0.000254     6.77
-    sub      0.000934         0.000175     5.34
-    eq       0.000267          0.00049    0.545
-    neq      6.91e-06          4.1e-05    0.169
-    andlen    0.00132         0.000206     6.41
+                    set()  RoaringBitmap()    ratio
+    init          0.00054          0.00668   0.0808
+    and          0.000404         8.51e-05     4.75
+    or           0.000537         9.48e-05     5.67
+    xor          0.000452         8.36e-05     5.41
+    sub          0.000401         6.97e-05     5.75
+    eq           0.000159         0.000831    0.191
+    neq          2.61e-06         2.05e-05    0.127
+    andlen       0.000416         5.47e-05     7.61
+    orlen        0.000532         4.43e-05       12
+    jaccard_dist  0.00113         0.000105     10.8
 
     dense set / high load factor
     100 runs with sets of 39800 random elements n s.t. 0 <= n < 40000
-                set()  RoaringBitmap()    ratio
-    init        0.425             1.97    0.216
-    and         0.363         0.000484      749
-    or          0.573         0.000471     1216
-    xor         0.521          0.00048     1084
-    sub         0.258          0.00047      548
-    eq         0.0703           0.0144     4.89
-    neq      1.41e-05         8.01e-05    0.176
-    andlen      0.367         0.000249     1472
+                    set()  RoaringBitmap()    ratio
+    init             0.18             1.37    0.132
+    and            0.0962         0.000152      633
+    or               0.17         0.000137     1248
+    xor             0.123         0.000134      912
+    sub             0.074         0.000138      537
+    eq             0.0335           0.0133     2.53
+    neq          4.24e-06         2.44e-05    0.174
+    andlen         0.0962         7.74e-05     1244
+    orlen           0.185         8.97e-05     2057
+    jaccard_dist    0.299         0.000168     1786
 
     medium load factor
     100 runs with sets of 59392 random elements n s.t. 0 <= n < 118784
-                set()  RoaringBitmap()    ratio
-    init        0.812                2    0.405
-    and         0.704         0.000533     1320
-    or           1.07         0.000528     2034
-    xor          1.08         0.000985     1092
-    sub         0.494         0.000986      501
-    eq           0.15           0.0319     4.69
-    neq       1.5e-05         9.49e-05    0.158
-    andlen      0.882         0.000489     1804
-
+                    set()  RoaringBitmap()    ratio
+    init            0.245             2.04     0.12
+    and             0.263         0.000287      914
+    or              0.418         0.000284     1473
+    xor             0.314         0.000283     1107
+    sub             0.157         0.000292      536
+    eq             0.0674           0.0295     2.28
+    neq          5.04e-06         2.57e-05    0.196
+    andlen          0.262         0.000175     1501
+    orlen           0.468         0.000158     2970
+    jaccard_dist    0.759         0.000315     2411
 References
 ----------
 Samy Chambi, Daniel Lemire, Owen Kaser, Robert Godin (2014),

--- a/src/arrayops.pxi
+++ b/src/arrayops.pxi
@@ -137,7 +137,8 @@ cdef int union2by2(uint16_t *data1, uint16_t *data2,
 					k2 += 1
 				return pos
 		elif data1[k1] == data2[k2]:
-			dest[pos] = data1[k1]
+			if dest is not NULL:
+				dest[pos] = data1[k1]
 			pos += 1
 			k1 += 1
 			k2 += 1
@@ -156,7 +157,8 @@ cdef int union2by2(uint16_t *data1, uint16_t *data2,
 					k1 += 1
 				return pos
 		else:  # data1[k1] > data2[k2]
-			dest[pos] = data2[k2]
+			if dest is not NULL:
+				dest[pos] = data2[k2]
 			pos += 1
 			k2 += 1
 			if k2 >= length2:

--- a/src/bitops.pxi
+++ b/src/bitops.pxi
@@ -9,6 +9,7 @@
 # cdef inline void bitsetintersectinplace(uint64_t *dest, uint64_t *src)
 # cdef inline void bitsetunion(uint64_t *dest, uint64_t *src1,
 # 		uint64_t *src2, int slots)
+# cdef inline int bitsetunioncount(uint64_t *src1, uint64_t *src2)
 # cdef inline void bitsetintersect(uint64_t *dest, uint64_t *src1,
 # 		uint64_t *src2, int slots)
 # cdef inline int bitsetintersectcount(uint64_t *src1, uint64_t *src2)
@@ -166,6 +167,17 @@ cdef inline void bitsetintersect(uint64_t *dest, uint64_t *src1,
 	cdef int a
 	for a in range(slots):
 		dest[a] = src1[a] & src2[a]
+
+
+cdef inline int bitsetunioncount(uint64_t *src1, uint64_t *src2):
+	"""return the cardinality of the union of dest and src.
+
+	Returns number of set bits in result.
+	Both operands are assumed to have a fixed number of bits ``BLOCKSIZE``."""
+	cdef int n, result = 0
+	for n in range(BLOCKSIZE // BITSIZE):
+		result += bit_popcount(src1[n] | src2[n])
+	return result
 
 
 cdef inline void bitsetunion(uint64_t *dest, uint64_t *src1, uint64_t *src2,

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -1,6 +1,6 @@
 """Benchmarks for roaringbitmap"""
 from __future__ import division, print_function, absolute_import, \
-        unicode_literals
+	 unicode_literals
 import random
 import timeit
 
@@ -168,6 +168,30 @@ def bench_andlen():
 	return a, b
 
 
+def bench_orlen():
+	a = timeit.Timer('len(ref | ref2)',
+			setup='from __main__ import DATA1, DATA2; '
+				'ref = set(DATA1); ref2 = set(DATA2)').timeit(number=M)
+	b = timeit.Timer('rb.union_len(rb2)',
+			setup='from __main__ import DATA1, DATA2; '
+				'from roaringbitmap import RoaringBitmap; '
+				'rb = RoaringBitmap(DATA1); '
+				'rb2 = RoaringBitmap(DATA2)').timeit(number=M)
+	return a, b
+
+
+def bench_jaccard_dist():
+	a = timeit.Timer('1 - (len(ref & ref2) / len(ref | ref2))',
+			setup='from __main__ import DATA1, DATA2; '
+				'ref = set(DATA1); ref2 = set(DATA2)').timeit(number=M)
+	b = timeit.Timer('rb.jaccard_dist(rb2)',
+			setup='from __main__ import DATA1, DATA2; '
+				'from roaringbitmap import RoaringBitmap; '
+				'rb = RoaringBitmap(DATA1); '
+				'rb2 = RoaringBitmap(DATA2)').timeit(number=M)
+	return a, b
+
+
 def main():
 	global N, MAX, DATA1, DATA2
 	for x in range(3):
@@ -189,7 +213,7 @@ def main():
 			MAX = 1 << 31
 		DATA1, DATA2 = pair()
 
-		fmt = '%8s %8s %16s %8s'
+		fmt = '%12s %8s %16s %8s'
 		numfmt = '%8.3g'
 		print('%d runs with sets of %d random elements n s.t. 0 <= n < %d' % (
 				M, N, MAX))
@@ -199,10 +223,11 @@ def main():
 				bench_or,  # bench_ior,
 				bench_xor,  # bench_ixor,
 				bench_sub,  # bench_isub,
-				bench_eq, bench_neq, bench_andlen):
+				bench_eq, bench_neq, bench_andlen, bench_orlen,
+				bench_jaccard_dist):
 			a, b = func()
 			ratio = a / b
-			print(fmt % (func.__name__.split('_', 1)[1].ljust(8),
+			print(fmt % (func.__name__.split('_', 1)[1].ljust(12),
 					numfmt % a, numfmt % b,
 					(numfmt % ratio) if ratio < 100 else int(ratio)))
 		print()

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,6 +1,6 @@
 """Unit tests for roaringbitmap"""
 from __future__ import division, print_function, absolute_import, \
-        unicode_literals
+	 unicode_literals
 import random
 import pytest
 import pickle
@@ -229,6 +229,18 @@ class Test_roaringbitmap(object):
 			ref, ref2 = set(data1), set(data2)
 			rb, rb2 = RoaringBitmap(data1), RoaringBitmap(data2)
 			assert len(ref & ref2) == rb.intersection_len(rb2)
+
+	def test_orlen(self, pair):
+		for data1, data2 in pair:
+			ref, ref2 = set(data1), set(data2)
+			rb, rb2 = RoaringBitmap(data1), RoaringBitmap(data2)
+			assert len((ref | ref2)) == rb.union_len(rb2)
+
+	def test_jaccard_dist(self, pair):
+		for data1, data2 in pair:
+			ref, ref2 = set(data1), set(data2)
+			rb, rb2 = RoaringBitmap(data1), RoaringBitmap(data2)
+			assert 1 - (len(ref & ref2)/len(ref | ref2)) == rb.jaccard_dist(rb2)
 
 	def test_rank(self, single):
 		for data in single:


### PR DESCRIPTION
The jaccard distance unit test fails because of a rounding error but I don't know enough about cython to fix that:
```
>        assert 1 - (len(ref & ref2)/len(ref | ref2)) == b.jaccard_dist(rb2)
E        assert (1 - (100 / 300)) == 0.6666666865348816
```
The other tests pass and the bench marks look good though :rocket: :smile: 