### PR TITLE
Use the _init2pass constructor for range.

### DIFF
--- a/src/roaringbitmap.pyx
+++ b/src/roaringbitmap.pyx
@@ -174,7 +174,7 @@ cdef class RoaringBitmap(object):
 				self._initrange(start, stop)
 				return
 			# fall through on non-trivial use of range()
-		if isinstance(iterable, (list, tuple, set, dict)):
+		if isinstance(iterable, (list, tuple, set, dict, RANGE)):
 			self._init2pass(iterable)
 		elif isinstance(iterable, RoaringBitmap):
 			ob = iterable


### PR DESCRIPTION
I was doing some tests and I came across a strange thing regarding performances. Creating a new `RoaringBitmap` from a `range` is much longer than creating it from a `list` containing the same values.

```bash
$ python3 -m timeit -s 'from roaringbitmap import RoaringBitmap; values = range(0, 10000000, 2)' 'x=RoaringBitmap(values)'
10 loops, best of 3: 783 msec per loop
$ python3 -m timeit -s 'from roaringbitmap import RoaringBitmap; values = list(range(0, 10000000, 2))' 'x=RoaringBitmap(values)'
10 loops, best of 3: 52.9 msec per loop
```

I was surprised, since you can manipulate a `range` pretty much as a `list`, so I do not understand why performances should be worse.

With this new version, the performances are better, albeit still not as good as with a `list`:
```bash
python3 -m timeit -s 'from roaringbitmap import RoaringBitmap; values = range(0, 10000000, 2)' 'x=RoaringBitmap(values)'      
10 loops, best of 3: 155 msec per loop
```