### PR TITLE
Add cython as build depency to avoid shipping pre-generated files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
Installing this package from pip fails with python 3.9, but it works just fine with the files from this repository. I guess the code in roaringbitmap.c is not compatible with recent versions of python.

[The cython manual](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#basic-setup-py) describes some way to add cython as a build dependency, so it is installed before running `setup.py` when running `pip install`. With that you should be able to distribute the cython files via pip.